### PR TITLE
strip declare(strict_types = 1) for php5.6 compatibility

### DIFF
--- a/src/Command/ClearCommand.php
+++ b/src/Command/ClearCommand.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Command;
 
 use Composer\Command\BaseCommand;

--- a/src/Command/CommandProvider.php
+++ b/src/Command/CommandProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Command;
 
 /**

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Config;
 
 /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner;
 
 use Composer\Composer;

--- a/src/Util/CategoryNormalizer.php
+++ b/src/Util/CategoryNormalizer.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Util;
 
 /**

--- a/src/Util/CleanerInterface.php
+++ b/src/Util/CleanerInterface.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php
 
 namespace OctoLab\Cleaner\Util;
 

--- a/src/Util/FakeCleaner.php
+++ b/src/Util/FakeCleaner.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Util;
 
 use Composer\IO\IOInterface;

--- a/src/Util/FileCleaner.php
+++ b/src/Util/FileCleaner.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Util;
 
 use Symfony\Component\Filesystem\Filesystem;

--- a/src/Util/FinderInterface.php
+++ b/src/Util/FinderInterface.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Util;
 
 /**

--- a/src/Util/GlobFinder.php
+++ b/src/Util/GlobFinder.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Util;
 
 /**

--- a/src/Util/MatcherInterface.php
+++ b/src/Util/MatcherInterface.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php
 
 namespace OctoLab\Cleaner\Util;
 

--- a/src/Util/NormalizerInterface.php
+++ b/src/Util/NormalizerInterface.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php
 
 namespace OctoLab\Cleaner\Util;
 

--- a/src/Util/WeightMatcher.php
+++ b/src/Util/WeightMatcher.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types = 1);
-
 namespace OctoLab\Cleaner\Util;
 
 /**


### PR DESCRIPTION
declare(strict_types = 1) is not necessary, since strict type hinting is not used in any method. When it's removed, the plugin runs fine on php 5.6 without warnings.
