### PR TITLE
handle "composer octolab:cleaner [package]" command

### DIFF
--- a/tests/Command/CleanCommandTest.php
+++ b/tests/Command/CleanCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace OctoLab\Cleaner\Command;
 
+use OctoLab\Cleaner\Plugin;
 use OctoLab\Cleaner\TestCase;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -17,13 +18,40 @@ class CleanCommandTest extends TestCase
      * @test
      */
     public function execute()
-    {
+	{
         $command = new ClearCommand();
+
+		$pluginManager = $this->getMockBuilder('Composer\Plugin\PluginManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$pluginManager->method('getPlugins')
+			->willReturn(new Plugin());
+
+		$repo = $this->getMock('Composer\Repository\WritableRepositoryInterface');
+		$repo->method('getPackages')
+			->willReturn([]);
+
+		$repositoryManager = $this->getMockBuilder('Composer\Repository\RepositoryManager')
+			->disableOriginalConstructor()
+			->getMock();
+		$repositoryManager->method('getLocalRepository')
+			->willReturn($repo);
+
+        $composer = $this->getMock('Composer\Composer');
+        $composer->method('getPluginManager')
+        	->willReturn($pluginManager);
+		$composer->method('getRepositoryManager')
+        	->willReturn($repositoryManager);
+
+        $command->setComposer($composer);
+
         $reflection = new \ReflectionObject($command);
         $method = $reflection->getMethod('execute');
         $method->setAccessible(true);
 
-        $input = new ArgvInput();
+        $input = $this->getMockBuilder(ArgvInput::class)->getMock();
+        $input->method('getArgument')
+        	->willReturn('');
         $output = new BufferedOutput();
         self::assertEquals(0, $method->invoke($command, $input, $output));
     }


### PR DESCRIPTION
## Questionnaire

| Q | A |
| :-- | :-- |
| Branch? | master |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
## Description

Turned "composer octolab:cleaner [package]" command into working state.
Also, it's possible to define "extras: dev-files" in the main composer.json file. If a package specified in "config: octolab-cleaner: clear" does not have "extras: dev-files" in its composer.json file, the ones from main composer.json will be considered when cleaning up that package.
