### PR TITLE
assert(): php 7.2 compat: Usage of a string as the assertion became deprecated

### DIFF
--- a/src/Util/FakeCleaner.php
+++ b/src/Util/FakeCleaner.php
@@ -30,7 +30,8 @@ final class FakeCleaner implements CleanerInterface
      */
     public function clear($packagePath, array $devFiles)
     {
-        assert('is_string($packagePath) && is_readable($packagePath)');
+        assert(is_string($packagePath));
+        assert(is_readable($packagePath));
         $result = array();
         if ($devFiles !== array()) {
             $this->finder->setCurrentDir($packagePath);

--- a/src/Util/FileCleaner.php
+++ b/src/Util/FileCleaner.php
@@ -27,7 +27,8 @@ final class FileCleaner implements CleanerInterface
      */
     public function clear($packagePath, array $devFiles)
     {
-        assert('is_string($packagePath) && is_readable($packagePath)');
+        assert(is_string($packagePath));
+        assert(is_readable($packagePath));
         $result = array();
         $this->finder->setCurrentDir($packagePath);
         foreach ($devFiles as $group => $patterns) {

--- a/src/Util/GlobFinder.php
+++ b/src/Util/GlobFinder.php
@@ -21,7 +21,7 @@ final class GlobFinder implements FinderInterface
         $before = getcwd();
         chdir($cwd = $this->current);
         foreach ($patterns as $pattern) {
-            assert('is_string($pattern)');
+            assert(is_string($pattern));
             if ($pattern[0] === '!') {
                 foreach (glob(substr($pattern, 1)) as $file) {
                     unset($files[$file]);

--- a/src/Util/WeightMatcher.php
+++ b/src/Util/WeightMatcher.php
@@ -20,7 +20,7 @@ final class WeightMatcher implements MatcherInterface
      */
     public function match($package, array $devFileGroups)
     {
-        assert('is_string($package)');
+        assert(is_string($package));
         $sortedRules = array();
         $packageNamespace = false !== ($pos = strpos($package, '/')) ? substr($package, 0, $pos) : '';
         if (isset($this->rules[$package])) {
@@ -86,7 +86,7 @@ final class WeightMatcher implements MatcherInterface
             self::ALL => false,
         );
         foreach ($rules as $rule) {
-            assert('is_string($rule)');
+            assert(is_string($rule));
             switch (true) {
                 case $rule === '*':
                     $sorted[self::ALL] = true;


### PR DESCRIPTION
It now emits an E_DEPRECATED notice when both assert.active and zend.assertions are set to 1.

Changed it to a syntax accepted by both php5 and 7.x